### PR TITLE
feat : 임시 날씨 api 생성 후 호출하는 기능 추가

### DIFF
--- a/config-test/src/app.module.ts
+++ b/config-test/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { WeatherModule } from './weather/weather.module';
 
 @Module({
-  imports: [ConfigModule.forRoot()],
+  imports: [ConfigModule.forRoot(), WeatherModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/config-test/src/weather/weather.controller.ts
+++ b/config-test/src/weather/weather.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Controller('weather')
+export class WeatherController {
+  constructor(private configService: ConfigService) {}
+
+  @Get()
+  public getWeather(): string {
+    const apiUrl = this.configService.get('WEATHER_API_URL');
+    const apiKey = this.configService.get('WEATHER_API_KEY');
+
+    // 날씨 API 호출
+    return this.callWeatherApi(apiUrl, apiKey);
+  }
+
+  private callWeatherApi(apiUrl: string, apiKey: string): string {
+    console.log('날씨 정보 가져오는 중...');
+    console.log(apiUrl);
+    console.log(apiKey);
+    return '내일은 맑음';
+  }
+}

--- a/config-test/src/weather/weather.module.ts
+++ b/config-test/src/weather/weather.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { WeatherController } from './weather.controller';
+
+@Module({
+  controllers: [WeatherController],
+})
+export class WeatherModule {}


### PR DESCRIPTION
npm run start:dev로 실행 후 localhost:3000/weather에서 날씨 확인 가능한 기능 추가
임시로 api를 생성하였기 때문에 실제 api를 가져와서 사용 가능하다